### PR TITLE
feat(toaster): Adding sonner for toasters

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-responsive": "^10.0.0",
     "react-spinners": "^0.17.0",
     "slugify": "^1.6.6",
+    "sonner": "^2.0.3",
     "swiper": "^11.1.15",
     "tailwindcss": "^4.1.7",
     "truncate": "^3.0.0",

--- a/src/client/components/layout/middle/Layout.tsx
+++ b/src/client/components/layout/middle/Layout.tsx
@@ -2,6 +2,8 @@
 
 import { Breadcrumb, Layout as AntLayout, Menu } from 'antd';
 import React, { lazy, ReactNode, Suspense } from 'react';
+// Toaster
+import { Toaster } from 'sonner';
 
 import '@/client/styles/components/layout/layout.scss';
 
@@ -105,6 +107,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           </header>
           <Content className='layout__main-content__content'>
             <Suspense fallback={<Loader />}>
+              <Toaster richColors position='bottom-right' />
               {PageComponent ? <PageComponent /> : children}
             </Suspense>
           </Content>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8878,6 +8878,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sonner@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "sonner@npm:2.0.3"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10c0/59f84142f7a692dd1ec90e6df2003a70ff0b325eaef1d5dd17ad250e7f992b71053824f1a7ab3912f8c4caa5ce30523a096b5f5108b3e8ae13f906048691aca1
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -9291,6 +9301,7 @@ __metadata:
     react-spinners: "npm:^0.17.0"
     sass: "npm:^1.83.0"
     slugify: "npm:^1.6.6"
+    sonner: "npm:^2.0.3"
     swiper: "npm:^11.1.15"
     tailwindcss: "npm:^4.1.7"
     truncate: "npm:^3.0.0"


### PR DESCRIPTION
## Décris tes modifications • Describe your changes

Ajout de la librairie Sonner pour l'utilisation des toaster avec l'appel de <Toaster /> dans le layout principal

utilisation avec la fonction toast()

Documentation : https://sonner.emilkowal.ski/
-

## Capture(s) d'écran • Screenshot(s)

## Réparent le(s) bug(s) • Fix bug(s)

- Répare • Fix #
- Répare • Fix #
